### PR TITLE
v39.1: CompositeMicro — microstructure soft gating; MACD gate removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v39.1] - 2025-08-08
+### Added
+- Composite soft gating using 1m CVD (uptick/downtick rule), IBS, CLV, NR7, IBR
+- Liquidity (vol z→sigmoid), Compression(TR/avgTR inverse) soft weights
+- Standardized final scores: sig_final_long / sig_final_short
+- Optional CVD divergence penalty
+### Removed
+- MACD-based gating
+### Notes
+- Anti-repaint: barstate.isconfirmed only; request.security lookahead_off strictly.
+
+
 ## v39.0-dev – 2025-07-10
 - Introduced MACD gating with adaptive weight to align trades with trend
 - Bump `ahft_utils` library to v2 and update import path to `/2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Liquidity (vol z→sigmoid), Compression(TR/avgTR inverse) soft weights
 - Standardized final scores: sig_final_long / sig_final_short
 - Optional CVD divergence penalty
+- Soft cooldown guard and MAE/MFE trade logging
 ### Removed
 - MACD-based gating
 ### Notes

--- a/configs/baseline_v39.1.pineconfig
+++ b/configs/baseline_v39.1.pineconfig
@@ -1,0 +1,28 @@
+{
+  "script_path": "scripts/AHFT-CompositeMicro-v39.1.pine",
+  "inputs": {
+    "long_threshold_[0..1]": 0.25,
+    "short_threshold_[0..1]": 0.25,
+    "rsi_len": 14,
+    "roc_len": 14,
+    "mix_rsiΔ~roc_(0..1)": 0.5,
+    "cvd_z-score_lookback": 50,
+    "use_nr7_compression": true,
+    "use_ibr_(inside_bar_ratio)": true,
+    "use_cvd_divergence": true,
+    "cvd_divergence_lookback": 50,
+    "cvd_divergence_penalty": 0.7,
+    "liquidity_weight_(vol_z→sigmoid)": true,
+    "compression_weight_(tr/avgtr)": true,
+    "micro_weight_(ibs/clv/cvd/nr7/ibr)": true,
+    "atr_len": 14,
+    "sl_atr_mult": 2.0,
+    "tp1_(r_multiple)": 1.0,
+    "tp2_(r_multiple)": 2.0,
+    "tp1_close_(%)": 50
+  },
+  "symbols": ["BINANCE:BTCUSDT"],
+  "timeframes": ["240","60","15"],
+  "start": "2023-01-01",
+  "end": "2025-07-31"
+}

--- a/configs/baseline_v39.1.pineconfig
+++ b/configs/baseline_v39.1.pineconfig
@@ -10,8 +10,8 @@
     "use_nr7_compression": true,
     "use_ibr_(inside_bar_ratio)": true,
     "use_cvd_divergence": true,
-    "cvd_divergence_lookback": 50,
-    "cvd_divergence_penalty": 0.7,
+    "cvd_divergence_window": 50,
+    "cvd_divergence_sensitivity": 1.0,
     "liquidity_weight_(vol_z→sigmoid)": true,
     "compression_weight_(tr/avgtr)": true,
     "micro_weight_(ibs/clv/cvd/nr7/ibr)": true,
@@ -19,7 +19,11 @@
     "sl_atr_mult": 2.0,
     "tp1_(r_multiple)": 1.0,
     "tp2_(r_multiple)": 2.0,
-    "tp1_close_(%)": 50
+    "tp1_close_(%)": 50,
+    "consecutive_loss_trigger": 3,
+    "cooldown_bars": 10,
+    "cooldown_weight": 0.6,
+    "log_n_trades_for_mae_mfe": 20
   },
   "symbols": ["BINANCE:BTCUSDT"],
   "timeframes": ["240","60","15"],

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -3,6 +3,18 @@
 
 현재 패치 버전은 **v39.0-dev**이며, Pseudo-BO와 Patch-Lite 스텁 모듈이 기본 비활성으로 변경되었습니다.
 
+### v39.1 CompositeMicro
+
+- Replaces the legacy MACD trend gate with a microstructure composite layer.
+- Blends 1m CVD (uptick/downtick), IBS, CLV, NR7 and IBR, then applies
+  liquidity and compression soft weights (0.5..1.0).
+- All triggers run on confirmed bars only and `request.security` uses
+  `lookahead_off`.
+- Final scores are exposed as `sig_final_long` and `sig_final_short`.
+
+> The earlier MACD trend gate is deprecated; CompositeMicro is the new
+> default signal layer.
+
 AHFT v38.0 "Helios Nexus": 종합 기술 백서 및 개발 회고록
 [PART 1/30] 서문: 시장이라는 생명체를 향한 여정
 프로젝트의 시작: 하나의 근본적인 질문

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -8,6 +8,10 @@
 - Replaces the legacy MACD trend gate with a microstructure composite layer.
 - Blends 1m CVD (uptick/downtick), IBS, CLV, NR7 and IBR, then applies
   liquidity and compression soft weights (0.5..1.0).
+- Optional CVD divergence weight softens signals when price and 1 m CVD
+  pivots disagree.
+- Tracks recent trade MAE/MFE and applies a soft cooldown after
+  consecutive losses.
 - All triggers run on confirmed bars only and `request.security` uses
   `lookahead_off`.
 - Final scores are exposed as `sig_final_long` and `sig_final_short`.

--- a/docs/ROADMAP_v39.md
+++ b/docs/ROADMAP_v39.md
@@ -38,11 +38,13 @@ three timeframes nightly and posts metrics to GitHub PR. |
 
 ## Delivered
 
-- v39.1 – CompositeMicro: MACD gate removed; soft gating via 1m CVD, IBS, CLV, NR7, IBR; liquidity & compression weights; exposes sig_final_long/short
+- v39.1 – CompositeMicro: MACD gate removed; soft gating via 1m CVD, IBS,
+  CLV, NR7, IBR; optional CVD divergence penalty; liquidity & compression
+  weights; loss cooldown guard; MAE/MFE logging; exposes sig_final_long/short
 
 ## Next
 
-- v39.2 – Structure-aware filters and CVD divergence weighting
+- v39.2 – Structure-aware filters and enhanced CVD divergence weighting
 - v40 – Adaptive exits with MAE/MFE feedback
 
 ## Pine-Only Constraints

--- a/docs/ROADMAP_v39.md
+++ b/docs/ROADMAP_v39.md
@@ -36,6 +36,15 @@ three timeframes nightly and posts metrics to GitHub PR. |
 
 ---
 
+## Delivered
+
+- v39.1 – CompositeMicro: MACD gate removed; soft gating via 1m CVD, IBS, CLV, NR7, IBR; liquidity & compression weights; exposes sig_final_long/short
+
+## Next
+
+- v39.2 – Structure-aware filters and CVD divergence weighting
+- v40 – Adaptive exits with MAE/MFE feedback
+
 ## Pine-Only Constraints
 
 * Learning arrays must stay below 100 KB.

--- a/scripts/AHFT-CompositeMicro-v39.1.pine
+++ b/scripts/AHFT-CompositeMicro-v39.1.pine
@@ -22,9 +22,9 @@ group_micro = "Microstructure Primitives"
 lookDelta    = input.int(50, "CVD z-score Lookback", 10, 1000, group=group_micro)
 useNR7       = input.bool(true, "Use NR7 Compression", group=group_micro)
 useIBR       = input.bool(true, "Use IBR (Inside Bar Ratio)", group=group_micro)
-useCvdDiv    = input.bool(true, "Use CVD Divergence", group=group_micro)
-divLook      = input.int(50, "CVD Divergence Lookback", 5, 1000, group=group_micro)
-divPenalty   = input.float(0.7, "CVD Divergence Penalty", 0.5, 1.0, group=group_micro)
+useCvdDiv  = input.bool(true, "Use CVD Divergence", group=group_micro)
+cvdDivWin  = input.int(50, "CVD Divergence Window", 5, 1000, group=group_micro)
+cvdDivSens = input.float(1.0, "CVD Divergence Sensitivity", 0.1, 10.0, group=group_micro)
 
 group_weight = "Composite Soft Weights"
 w_liq_on   = input.bool(true,  "Liquidity weight (vol z→sigmoid)", group=group_weight)
@@ -37,6 +37,12 @@ atrSLmult  = input.float(2.0, "SL ATR Mult", 0.1, 10.0, group=group_risk)
 tp1R       = input.float(1.0, "TP1 (R multiple)", 0.2, 5.0, group=group_risk)
 tp2R       = input.float(2.0, "TP2 (R multiple)", 0.3, 10.0, group=group_risk)
 tp1pct     = input.float(50,  "TP1 Close (%)", 5, 95, group=group_risk)
+
+group_guard = "Risk Controls"
+lossTrig   = input.int(3, "Consecutive Loss Trigger", 1, 10, group=group_guard)
+lossCooldown = input.int(10, "Cooldown Bars", 1, 500, group=group_guard)
+cooldownW = input.float(0.6, "Cooldown Weight", 0.5, 1.0, group=group_guard)
+logTrades  = input.int(20, "Log N Trades for MAE/MFE", 1, 100, group=group_guard)
 
 // ===================== 2) UTILS =====================
 f_clamp(x, lo, hi) =>
@@ -81,14 +87,32 @@ cvdZ   = f_z(cvdDeltaBar, lookDelta)
 cvd01  = to01_from_z(cvdZ)
 
 // CVD divergence (optional soft weight)
-priceHH = ta.highest(high, divLook)
-priceLL = ta.lowest(low, divLook)
-cvdHH   = ta.highest(cvd1m, divLook)
-cvdLL   = ta.lowest(cvd1m, divLook)
-bearDiv = useCvdDiv and high >= priceHH[1] and cvd1m <= cvdHH[1]
-bullDiv = useCvdDiv and low <= priceLL[1] and cvd1m >= cvdLL[1]
-W_div_long  = bearDiv ? divPenalty : 1.0
-W_div_short = bullDiv ? divPenalty : 1.0
+phPrice = ta.pivothigh(high, 3, 3)
+plPrice = ta.pivotlow(low, 3, 3)
+phCvd   = ta.pivothigh(cvd1m, 3, 3)
+plCvd   = ta.pivotlow(cvd1m, 3, 3)
+var float prevPhPrice = na
+var float prevPhCvd = na
+var float prevPlPrice = na
+var float prevPlCvd = na
+bearStrength = 0.0
+bullStrength = 0.0
+bearDiv = false
+bullDiv = false
+if not na(phPrice)
+    bearDiv := useCvdDiv and not na(prevPhPrice) and phPrice > prevPhPrice and phCvd <= prevPhCvd
+    bearStrength := math.abs((phPrice - prevPhPrice) - (phCvd - prevPhCvd))
+    prevPhPrice := phPrice
+    prevPhCvd := phCvd
+if not na(plPrice)
+    bullDiv := useCvdDiv and not na(prevPlPrice) and plPrice < prevPlPrice and plCvd >= prevPlCvd
+    bullStrength := math.abs((prevPlPrice - plPrice) - (prevPlCvd - plCvd))
+    prevPlPrice := plPrice
+    prevPlCvd := plCvd
+bearZ = f_z(bearStrength, cvdDivWin)
+bullZ = f_z(bullStrength, cvdDivWin)
+W_div_long  = bearDiv ? 1.0 - 0.5 * f_sigmoid(bearZ * cvdDivSens) : 1.0
+W_div_short = bullDiv ? 1.0 - 0.5 * f_sigmoid(bullZ * cvdDivSens) : 1.0
 
 // 유동성(볼륨 z→sigmoid)
 volZ   = f_z(volume, lookDelta)
@@ -110,6 +134,32 @@ W_micro = w_micro_on ? soft01(microRaw01) : 1.0
 W_liq   = w_liq_on   ? soft01(liq01)      : 1.0
 W_vol   = w_vol_on   ? soft01(invComp01)  : 1.0
 
+// Cooldown guard and MAE/MFE logging
+var int lossStreak = 0
+var int cooldownLeft = 0
+var float[] maeLog = array.new_float()
+var float[] mfeLog = array.new_float()
+if strategy.closedtrades > strategy.closedtrades[1]
+    idx = strategy.closedtrades - 1
+    pl = strategy.closedtrades.profit(idx)
+    mae = strategy.closedtrades.max_drawdown(idx)
+    mfe = strategy.closedtrades.max_runup(idx)
+    array.unshift(maeLog, mae)
+    array.unshift(mfeLog, mfe)
+    if array.size(maeLog) > logTrades
+        array.pop(maeLog)
+        array.pop(mfeLog)
+    if pl < 0
+        lossStreak += 1
+    else
+        lossStreak := 0
+    if lossStreak >= lossTrig
+        cooldownLeft := lossCooldown
+        lossStreak := 0
+if cooldownLeft > 0
+    cooldownLeft -= 1
+W_cool = cooldownLeft > 0 ? cooldownW : 1.0
+
 // ===================== 4) BASE MOMENTUM (FALLBACK) =====================
 rsi    = ta.rsi(close, rsiLen)
 drsi   = rsi - rsi[1]
@@ -125,8 +175,8 @@ baseLongScore  = f_clamp(  momo, 0.0, 1.0)     // fallback: 상승 모멘텀만
 baseShortScore = f_clamp(- momo, 0.0, 1.0)     // fallback: 하락 모멘텀만
 
 // Composite soft weights 적용
-longScore_gated  = baseLongScore  * W_micro * W_liq * W_vol * W_div_long
-shortScore_gated = baseShortScore * W_micro * W_liq * W_vol * W_div_short
+longScore_gated  = baseLongScore  * W_micro * W_liq * W_vol * W_div_long  * W_cool
+shortScore_gated = baseShortScore * W_micro * W_liq * W_vol * W_div_short * W_cool
 
 // === 공개 표준 변수명 ===
 sig_final_long  = longScore_gated

--- a/scripts/AHFT-CompositeMicro-v39.1.pine
+++ b/scripts/AHFT-CompositeMicro-v39.1.pine
@@ -1,0 +1,188 @@
+//@version=5
+// ==============================================================================
+// 📚 프로젝트: AHFT - CompositeMicro (v39.1)
+// 🎯 핵심: MACD 게이트 제거. 1m CVD + IBS/CLV + NR7/IBR + CVD 다이버전스 + 유동성/압축 소프트 가중.
+// 🧱 헌장: Pine Script v5 불변의 개발 헌장 100% 준수 (Genesis Principle 포함).
+// 🔒 철학: 확정봉(barstate.isconfirmed) 기준 진입/알림 → 리페인트 차단.
+// ==============================================================================
+
+strategy(title="AHFT - CompositeMicro (v39.1)", shorttitle="AHFT-v39.1", overlay=true,initial_capital=100000, commission_type=strategy.commission.percent, commission_value=0.04, slippage=1, calc_on_every_tick=true, process_orders_on_close=false, max_bars_back=2000, pyramiding=0) 
+
+// ===================== 1) INPUTS =====================
+group_thr = "Entry Thresholds"
+thrLong   = input.float(0.25, "Long Threshold [0..1]", 0.00, 1.00, group=group_thr)
+thrShort  = input.float(0.25, "Short Threshold [0..1]",0.00, 1.00, group=group_thr)
+
+group_momo = "Base Momentum (Fallback)"
+rsiLen   = input.int(14, "RSI Len", 2, 200, group=group_momo)
+rocLen   = input.int(14, "ROC Len", 2, 200, group=group_momo)
+mixMomo  = input.float(0.5, "Mix RSIΔ~ROC (0..1)", 0.0, 1.0, group=group_momo)
+
+group_micro = "Microstructure Primitives"
+lookDelta    = input.int(50, "CVD z-score Lookback", 10, 1000, group=group_micro)
+useNR7       = input.bool(true, "Use NR7 Compression", group=group_micro)
+useIBR       = input.bool(true, "Use IBR (Inside Bar Ratio)", group=group_micro)
+useCvdDiv    = input.bool(true, "Use CVD Divergence", group=group_micro)
+divLook      = input.int(50, "CVD Divergence Lookback", 5, 1000, group=group_micro)
+divPenalty   = input.float(0.7, "CVD Divergence Penalty", 0.5, 1.0, group=group_micro)
+
+group_weight = "Composite Soft Weights"
+w_liq_on   = input.bool(true,  "Liquidity weight (vol z→sigmoid)", group=group_weight)
+w_vol_on   = input.bool(true,  "Compression weight (TR/avgTR)",    group=group_weight)
+w_micro_on = input.bool(true,  "Micro weight (IBS/CLV/CVD/NR7/IBR)",group=group_weight)
+
+group_risk = "Risk (Sample)"
+atrLen     = input.int(14, "ATR Len", 1, 200, group=group_risk)
+atrSLmult  = input.float(2.0, "SL ATR Mult", 0.1, 10.0, group=group_risk)
+tp1R       = input.float(1.0, "TP1 (R multiple)", 0.2, 5.0, group=group_risk)
+tp2R       = input.float(2.0, "TP2 (R multiple)", 0.3, 10.0, group=group_risk)
+tp1pct     = input.float(50,  "TP1 Close (%)", 5, 95, group=group_risk)
+
+// ===================== 2) UTILS =====================
+f_clamp(x, lo, hi) =>
+    x < lo ? lo : x > hi ? hi : x
+
+f_z(src, len) =>
+    m = ta.sma(src, len)
+    s = ta.stdev(src, len)
+    s > 0 ? (src - m)/s : 0.0
+
+f_sigmoid(x) =>
+    1.0 / (1.0 + math.exp(-x))
+
+to01_from_z(z) =>
+    f_sigmoid(z)  // z-score → 0..1
+
+soft01(w01) =>
+    0.5 + 0.5 * f_clamp(w01, 0.0, 1.0) // 0..1 → 0.5..1.0 (소프트 가중)
+
+// ===================== 3) MICRO PRIMITIVES =====================
+// IBS / CLV
+ib  = (high == low) ? 0.5 : (close - low) / (high - low)                     // [0..1]
+clv = (high == low) ? 0.0 : ((close - low) - (high - close)) / (high - low) // [-1..1]
+clv01 = 0.5 * (clv + 1.0)
+
+// NR7 / IBR
+tr    = ta.tr(true)
+rng   = high - low
+nr7   = useNR7 ? (rng < ta.lowest(rng, 7)[1]) : false
+ibr   = useIBR and (high <= high[1] and low >= low[1]) ? (rng / math.max(high[1]-low[1], 1e-6)) : na
+ibr01 = na(ibr) ? 0.5 : f_clamp(ibr, 0.0, 1.0)
+
+// 1분봉 CVD (uptick/downtick rule) - 확정값만 사용(lookahead_off)
+c1m = request.security(syminfo.tickerid, "1", close,  barmerge.gaps_off, barmerge.lookahead_off)
+v1m = request.security(syminfo.tickerid, "1", volume, barmerge.gaps_off, barmerge.lookahead_off)
+chg1m = c1m - c1m[1]
+sgn1m = chg1m > 0 ? 1 : chg1m < 0 ? -1 : 0
+delta1m = v1m * sgn1m
+cvd1m   = ta.cum(delta1m)
+cvdDeltaBar = ta.change(cvd1m)  // 현재 HTF 바에서 CVD 순변화 근사
+cvdZ   = f_z(cvdDeltaBar, lookDelta)
+cvd01  = to01_from_z(cvdZ)
+
+// CVD divergence (optional soft weight)
+priceHH = ta.highest(high, divLook)
+priceLL = ta.lowest(low, divLook)
+cvdHH   = ta.highest(cvd1m, divLook)
+cvdLL   = ta.lowest(cvd1m, divLook)
+bearDiv = useCvdDiv and high >= priceHH[1] and cvd1m <= cvdHH[1]
+bullDiv = useCvdDiv and low <= priceLL[1] and cvd1m >= cvdLL[1]
+W_div_long  = bearDiv ? divPenalty : 1.0
+W_div_short = bullDiv ? divPenalty : 1.0
+
+// 유동성(볼륨 z→sigmoid)
+volZ   = f_z(volume, lookDelta)
+liq01  = to01_from_z(volZ)
+
+// 압축 회피(TR/avgTR 역가중)
+avgTR  = ta.sma(tr, math.max(5, atrLen))
+comp   = avgTR > 0 ? tr / avgTR : 1.0
+comp01 = f_clamp(comp, 0.0, 2.0) / 2.0            // 0..1
+invComp01 = 1.0 - comp01                          // 압축(낮은 TR)일수록 ↑
+
+// Micro-score: IBS/CLV/CVD(+NR7/IBR) 혼합 → W_micro
+microRaw01 = 0.35*ib + 0.35*clv01 + 0.30*cvd01
+microRaw01 := na(ibr01) ? microRaw01 : (microRaw01*0.85 + 0.15*ibr01)
+microRaw01 := nr7 ? math.min(1.0, microRaw01 + 0.05) : microRaw01
+W_micro = w_micro_on ? soft01(microRaw01) : 1.0
+
+// Liquidity / Compression soft weights
+W_liq   = w_liq_on   ? soft01(liq01)      : 1.0
+W_vol   = w_vol_on   ? soft01(invComp01)  : 1.0
+
+// ===================== 4) BASE MOMENTUM (FALLBACK) =====================
+rsi    = ta.rsi(close, rsiLen)
+drsi   = rsi - rsi[1]
+roc    = ta.roc(close, rocLen)
+momo01 = f_clamp( mixMomo * to01_from_z(f_z(drsi, rsiLen)) + (1.0 - mixMomo) * to01_from_z(f_z(roc, rocLen)), 0.0, 1.0)
+momo   = 2.0*momo01 - 1.0   // [-1..1]
+
+// ===================== 5) FINAL SCORES =====================
+// ⚠️ 네 엔진의 최종 스코어가 이미 있다면, 아래 두 줄만 "네 변수명"으로 교체하면 됨.
+// baseLongScore  := your_final_long_score   // (0..1)
+// baseShortScore := your_final_short_score  // (0..1)
+baseLongScore  = f_clamp(  momo, 0.0, 1.0)     // fallback: 상승 모멘텀만
+baseShortScore = f_clamp(- momo, 0.0, 1.0)     // fallback: 하락 모멘텀만
+
+// Composite soft weights 적용
+longScore_gated  = baseLongScore  * W_micro * W_liq * W_vol * W_div_long
+shortScore_gated = baseShortScore * W_micro * W_liq * W_vol * W_div_short
+
+// === 공개 표준 변수명 ===
+sig_final_long  = longScore_gated
+sig_final_short = shortScore_gated
+
+// ===================== 6) ENTRY/EXIT (SAMPLE, 확정봉만) =====================
+confirmed = barstate.isconfirmed
+enterLong  = confirmed and (sig_final_long  > thrLong)
+enterShort = confirmed and (sig_final_short > thrShort)
+
+atr = ta.atr(atrLen)
+R   = atr * atrSLmult
+
+// 샘플 포지션 사이징: 자본 20% 명목
+equity = strategy.equity
+notional = equity * 0.20
+qty     = notional / close
+
+longID  = "LONG"
+shortID = "SHORT"
+
+if (enterLong and strategy.position_size <= 0)
+    strategy.entry(longID, strategy.long, qty=qty)
+    alert("LONG_CONFIRMED|price=" + str.tostring(close), alert.freq_once_per_bar_close)
+
+if (enterShort and strategy.position_size >= 0)
+    strategy.entry(shortID, strategy.short, qty=qty)
+    alert("SHORT_CONFIRMED|price=" + str.tostring(close), alert.freq_once_per_bar_close)
+
+// SL/TP (부분청산 + 보호)
+inLong  = strategy.position_size > 0
+inShort = strategy.position_size < 0
+avgFill = strategy.position_avg_price
+
+if (inLong)
+    longSL  = avgFill - R
+    longTP1 = avgFill + R*tp1R
+    longTP2 = avgFill + R*tp2R
+    strategy.exit("L-TP1", from_entry=longID, limit=longTP1, qty_percent=tp1pct)
+    strategy.exit("L-TP2", from_entry=longID, limit=longTP2, qty_percent=100-tp1pct, stop=longSL)
+
+if (inShort)
+    shortSL  = avgFill + R
+    shortTP1 = avgFill - R*tp1R
+    shortTP2 = avgFill - R*tp2R
+    strategy.exit("S-TP1", from_entry=shortID, limit=shortTP1, qty_percent=tp1pct)
+    strategy.exit("S-TP2", from_entry=shortID, limit=shortTP2, qty_percent=100-tp1pct, stop=shortSL)
+
+// ===================== 7) PLOTS =====================
+plot(sig_final_long,  "sig_final_long [0..1]",  color=color.new(color.lime,  0))
+plot(sig_final_short, "sig_final_short[0..1]",  color=color.new(color.red,   0))
+plot(ib,              "IBS",                    color=color.new(color.aqua,  40))
+plot(clv01,           "CLV01",                  color=color.new(color.orange,40))
+plot(cvd01,           "CVD01(1m)",              color=color.new(color.blue,  40))
+
+// ===================== 8) 주의/검증 메모 =====================
+// - 모든 트리거는 확정봉 기준(리페인트 회피). request.security는 lookahead_off.
+// - strategy.exit 는 from_entry/qty_percent 정확히 사용. Pine v5 문법 일치.
+// - 외부 엔진 연결 시 baseLong/ShortScore 교체만 수행(엔진 불변 원칙).

--- a/tools/run_regression_v39_1.py
+++ b/tools/run_regression_v39_1.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse, subprocess, sys, os, datetime as dt
+
+DEFAULT_SCRIPT = "scripts/AHFT-CompositeMicro-v39.1.pine"
+DEFAULT_CFG    = "configs/baseline_v39.1.pineconfig"
+DEFAULT_SYMS   = ["BINANCE:BTCUSDT"]
+DEFAULT_TFS    = ["240","60","15"]
+
+def run_once(script, cfg, sym, tfs, start, end, outdir):
+    os.makedirs(outdir, exist_ok=True)
+    out = os.path.join(outdir, f"v39_1_{sym.replace(':','_')}_{'-'.join(tfs)}.html")
+    cmd = [
+        sys.executable, "-m", "tvscript_tester.run",
+        "--script", script,
+        "--config", cfg,
+        "--symbols", sym,
+        "--timeframes", ",".join(tfs),
+        "--start", start,
+        "--end", end,
+        "--report", out,
+    ]
+    print(">>", " ".join(cmd))
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        print("WARNING: tvscript_tester failed. Proceeding without report.", file=sys.stderr)
+        return None
+    return out
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--script", default=DEFAULT_SCRIPT)
+    ap.add_argument("--config", default=DEFAULT_CFG)
+    ap.add_argument("--symbols", nargs="+", default=DEFAULT_SYMS)
+    ap.add_argument("--timeframes", nargs="+", default=DEFAULT_TFS)
+    ap.add_argument("--start", default="2023-01-01")
+    ap.add_argument("--end", default=dt.date.today().isoformat())
+    ap.add_argument("--outdir", default="reports")
+    args = ap.parse_args()
+
+    reports = []
+    for s in args.symbols:
+        r = run_once(args.script, args.config, s, args.timeframes, args.start, args.end, args.outdir)
+        if r: reports.append(r)
+
+    print("\nGenerated reports:")
+    for r in reports:
+        print(" -", r)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Remove MACD-based gating.
- Add Composite soft gating using 1m CVD (uptick/downtick rule), IBS, CLV, NR7, IBR, optional CVD divergence.
- Liquidity (vol z→sigmoid) and Compression(TR/avgTR inverse) soft weights.
- Standard final scores: `sig_final_long`, `sig_final_short`.
- Documented CompositeMicro in PROJECT and roadmap; added regression config.

## Tests
- `python tools/run_regression_v39_1.py` *(tvscript_tester missing; warning shown)*.
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68959aec9564832eb82bc7a8c1d24381